### PR TITLE
feat: migração da navbar móvel para o rodapé

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -115,6 +115,55 @@
     <script src="~/js/rest-timer.js" asp-append-version="true"></script>
     <script src="~/js/rest-timer-ui.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
+
+    @{
+        var currentController = ViewContext.RouteData.Values["controller"]?.ToString()?.ToLower() ?? "";
+    }
+    @if (User?.Identity?.IsAuthenticated == true)
+    {
+        <nav class="bottom-nav" aria-label="Navegação principal">
+            <a class="bottom-nav-item @(currentController == "home" ? "active" : "")" asp-controller="Home" asp-action="Index">
+                <i class="fas fa-home"></i>
+                <span>Início</span>
+            </a>
+            <a class="bottom-nav-item @(currentController == "training" ? "active" : "")" asp-controller="Training" asp-action="Index">
+                <i class="fas fa-dumbbell"></i>
+                <span>Treinos</span>
+            </a>
+            <a class="bottom-nav-item @(currentController == "workoutplan" ? "active" : "")" asp-controller="WorkoutPlan" asp-action="Index">
+                <i class="fas fa-clipboard-list"></i>
+                <span>Planos</span>
+            </a>
+            @if (User.IsInRole("Admin"))
+            {
+                <a class="bottom-nav-item @(currentController == "admin" ? "active" : "")" asp-controller="Admin" asp-action="Index">
+                    <i class="fas fa-cog"></i>
+                    <span>Admin</span>
+                </a>
+            }
+            <a class="bottom-nav-item @(currentController == "user" ? "active" : "")" asp-controller="User" asp-action="Index">
+                <i class="fas fa-user"></i>
+                <span>Conta</span>
+            </a>
+        </nav>
+    }
+    else
+    {
+        <nav class="bottom-nav" aria-label="Navegação">
+            <a class="bottom-nav-item @(currentController == "home" ? "active" : "")" asp-controller="Home" asp-action="Index">
+                <i class="fas fa-home"></i>
+                <span>Início</span>
+            </a>
+            <a class="bottom-nav-item @(currentController == "user" && ViewContext.RouteData.Values["action"]?.ToString()?.ToLower() == "login" ? "active" : "")" asp-controller="User" asp-action="Login">
+                <i class="fas fa-sign-in-alt"></i>
+                <span>Login</span>
+            </a>
+            <a class="bottom-nav-item @(currentController == "user" && ViewContext.RouteData.Values["action"]?.ToString()?.ToLower() == "register" ? "active" : "")" asp-controller="User" asp-action="Register">
+                <i class="fas fa-user-plus"></i>
+                <span>Registrar</span>
+            </a>
+        </nav>
+    }
 </body>
 
 </html>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2075,3 +2075,135 @@ body.has-active-session .pre-alpha-badge {
     75% { transform: translateX(10px); }
 }
 
+
+/* ======================================
+   Mobile Bottom Navigation — One UI Style
+   ====================================== */
+
+.bottom-nav {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 65px;
+    background: rgba(255, 255, 255, 0.93);
+    backdrop-filter: blur(24px) saturate(200%);
+    -webkit-backdrop-filter: blur(24px) saturate(200%);
+    border-top: 1px solid rgba(0, 0, 0, 0.07);
+    box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.06),
+                0 -1px 4px rgba(0, 0, 0, 0.04);
+    z-index: 9997;
+    justify-content: space-around;
+    align-items: stretch;
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.bottom-nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    text-decoration: none;
+    color: #9aa0ab;
+    position: relative;
+    gap: 3px;
+    padding: 8px 6px 6px;
+    transition: color 0.2s ease;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+}
+
+.bottom-nav-item:hover,
+.bottom-nav-item:focus {
+    text-decoration: none;
+    color: #555;
+    outline: none;
+}
+
+.bottom-nav-item i {
+    font-size: 1.3rem;
+    line-height: 1;
+    position: relative;
+    z-index: 1;
+    transition: transform 0.25s cubic-bezier(0.2, 0.9, 0.2, 1);
+}
+
+.bottom-nav-item span {
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    position: relative;
+    z-index: 1;
+    transition: color 0.2s ease;
+}
+
+/* Active pill indicator */
+.bottom-nav-item::before {
+    content: '';
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%) scaleX(0.5);
+    width: 52px;
+    height: 30px;
+    background: transparent;
+    border-radius: 12px;
+    transition: background 0.2s ease,
+                transform 0.25s cubic-bezier(0.2, 0.9, 0.2, 1);
+    pointer-events: none;
+}
+
+.bottom-nav-item.active {
+    color: #0d6efd;
+}
+
+.bottom-nav-item.active i {
+    transform: translateY(-1px) scale(1.05);
+}
+
+.bottom-nav-item.active::before {
+    background: rgba(13, 110, 253, 0.12);
+    transform: translateX(-50%) scaleX(1);
+}
+
+/* ======================================
+   Mobile-specific overrides
+   ====================================== */
+
+@media (max-width: 575.98px) {
+    header {
+        display: none;
+    }
+
+    .bottom-nav {
+        display: flex;
+    }
+
+    body {
+        margin-top: 0.75rem;
+        padding-bottom: 85px;
+    }
+
+    /* Push fixed-bottom elements above the bottom nav */
+    .pre-alpha-badge {
+        bottom: 65px;
+    }
+
+    .active-session-card {
+        bottom: 65px;
+        padding-bottom: 12px;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom: none;
+    }
+
+    .active-session-card:not([class*="border-radius"]) {
+        border-radius: 1rem;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+}


### PR DESCRIPTION
- Adicionada a `bottom-nav` para navegação em dispositivos móveis.
- Implementados links para as seções `Home`, `Treinos`, `Planos`, `Admin` e `Conta`.
- Estilização da `bottom-nav` em `site.css` para exibição em telas pequenas.
- Ocultado o `header` em dispositivos móveis.

closes #38 